### PR TITLE
Implement CustomSchemaGeneratorHookProvider 

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -36,6 +36,7 @@ val graphqlKotlinVersion = "5.1.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jooq:2.6.5")
+    implementation("com.expediagroup", "graphql-kotlin-hooks-provider", graphqlKotlinVersion)
     implementation("org.jooq:jooq-codegen:3.16.5")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/api/src/main/kotlin/com/okeicalm/simpleJournalEntry/handler/scalar/CustomSchemaGeneratorHooksProvider.kt
+++ b/api/src/main/kotlin/com/okeicalm/simpleJournalEntry/handler/scalar/CustomSchemaGeneratorHooksProvider.kt
@@ -1,0 +1,8 @@
+package com.okeicalm.simpleJournalEntry.handler.scalar
+
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+
+class CustomSchemaGeneratorHooksProvider: SchemaGeneratorHooksProvider {
+    override fun hooks(): SchemaGeneratorHooks = CustomSchemaGeneratorHooks()
+}

--- a/api/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/api/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,0 +1,2 @@
+com.okeicalm.simpleJournalEntry.handler.scalar.MyCustomSchemaGeneratorHooksProvider
+

--- a/api/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/api/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,2 +1,2 @@
-com.okeicalm.simpleJournalEntry.handler.scalar.MyCustomSchemaGeneratorHooksProvider
+com.okeicalm.simpleJournalEntry.handler.scalar.CustomSchemaGeneratorHooksProvider
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,12 @@ services:
     container_name: mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-#      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_USER: mysqluser
-#      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_PASSWORD: password
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_DATABASE: simple_journal_entry_db
     restart: always
     ports:
-#      - ${MYSQL_PORT}:3306
-      -  "3306:3306"
+      - ${MYSQL_PORT}:3306
     volumes:
       - ./docker/mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
       - ./docker/mysql/initdb.d:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,15 @@ services:
     container_name: mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+#      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_USER: mysqluser
+#      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_PASSWORD: password
       MYSQL_DATABASE: simple_journal_entry_db
     restart: always
     ports:
-      - ${MYSQL_PORT}:3306
+#      - ${MYSQL_PORT}:3306
+      -  "3306:3306"
     volumes:
       - ./docker/mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
       - ./docker/mysql/initdb.d:/docker-entrypoint-initdb.d

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -29,7 +29,7 @@ directive @specifiedBy(
 
 type Account {
   code: String!
-  elementType: Int!
+  elementType: AccountElementType!
   id: ID!
   name: String!
 }
@@ -40,13 +40,13 @@ type DeleteAccountPayload {
 
 type Journal {
   id: ID!
-  journalEntries: [JournalEntry!]
+  incurredOn: Date!
+  journalEntries: [JournalEntry!]!
 }
 
 type JournalEntry {
-  accountId: ID!
+  account: Account!
   id: ID!
-  journalId: ID!
   side: Int!
   value: Int!
 }
@@ -63,9 +63,21 @@ type Query {
   allJournals: [Journal!]!
 }
 
+enum AccountElementType {
+  ASSETS
+  EXPENSES
+  LIABILITIES
+  NET_ASSETS
+  NET_INCOME
+  REVENUE
+}
+
+"An RFC-3339 compliant Full Date Scalar"
+scalar Date
+
 input CreateAccountInput {
   code: String!
-  elementType: Int!
+  elementType: AccountElementType!
   name: String!
 }
 
@@ -86,7 +98,7 @@ input DeleteAccountInput {
 
 input UpdateAccountInput {
   code: String!
-  elementType: Int!
+  elementType: AccountElementType!
   id: ID!
   name: String!
 }


### PR DESCRIPTION
### Changes
CustomSchemaGeneratorHookProvider has been implemented.

### Reason for the changes
Since CustomSchemaGeneratorHook cannot run properly which induces the failure of conversion of java.time.LocalDate, it is considered that CustomSchemaGeneratorHookProvider is necessary to ensure that all schemas can be generated from Kotlin objects properly.
(For details of the failure of conversion of java.time.LocalDate, please refer to the attached image.)

### Related links
No related links

### Test result
[ ] Run the command `./gradlew graphqlGenerateSDL` to check whether or not SDL can be generated properly. Error should not be observed when the generation of SDL is conducted successfully.
[ ]
[ ]

### Others
<img width="1204" alt="スクリーンショット 2022-09-29 10 10 23" src="https://user-images.githubusercontent.com/70248190/192915953-a07ea4c3-c665-495b-ae91-c5340ddb1dcc.png">
